### PR TITLE
fixbug: workday-offset due to index-error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 
 *.js
 *.ics
+.DS_Store

--- a/calendar_2025.ts
+++ b/calendar_2025.ts
@@ -177,8 +177,8 @@ events.push({
 /// 2025-2026学年第二学期于2026年3月1日至2026年7月4日，教学周共18周。
 
 for (let i = 0; i < 18; i++) {
-  const weekStart = new Date(2026, 3, 1).addWeek(i)
-  const weekEnd = new Date(2026, 3, 1).addWeek(i + 1)
+  const weekStart = new Date(2026, 2, 2).addWeek(i)
+  const weekEnd = new Date(2026, 2, 2).addWeek(i + 1)
 
   events.push({
     uid: uidGenerator(`term-2-week-${i + 1}`),


### PR DESCRIPTION
Date-Creation function in JavaScript starts its parameter fo month from 0, instead of 1,which could induce a workday/task-set offset.